### PR TITLE
Secp256k1::PublicKey#ecdh fails in an undefined method error

### DIFF
--- a/lib/secp256k1/c.rb
+++ b/lib/secp256k1/c.rb
@@ -85,7 +85,7 @@ module Secp256k1
     # int secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context *ctx, secp256k1_ecdsa_signature *sig, const secp256k1_ecdsa_recoverable_signature *sigin)
     attach_function :secp256k1_ecdsa_recoverable_signature_convert, [:pointer, :pointer, :pointer], :int
 
-    # int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar) {
+    # int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar)
     attach_function :secp256k1_ecdh, [:pointer, :pointer, :pointer, :pointer], :int
   end
 end

--- a/lib/secp256k1/c.rb
+++ b/lib/secp256k1/c.rb
@@ -85,5 +85,7 @@ module Secp256k1
     # int secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context *ctx, secp256k1_ecdsa_signature *sig, const secp256k1_ecdsa_recoverable_signature *sigin)
     attach_function :secp256k1_ecdsa_recoverable_signature_convert, [:pointer, :pointer, :pointer], :int
 
+    # int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar) {
+    attach_function :secp256k1_ecdh, [:pointer, :pointer, :pointer, :pointer], :int
   end
 end


### PR DESCRIPTION
Secp256k1::PublicKey#ecdh always fails for me.

my code is below.

```
public_key = ["028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"].pack("H*")
private_key = ["1212121212121212121212121212121212121212121212121212121212121212"].pack("H*")
key = ::Secp256k1::PublicKey.new(pubkey: public_key, raw: true)
shared_key = key.ecdh(private_key)
```

results in 
```
     NoMethodError:
       undefined method `secp256k1_ecdh' for Secp256k1::C:Module
       Did you mean?  secp256k1_ecdsa_sign
```
    