### PR TITLE
bug fix on ecdsa_verify

### DIFF
--- a/lib/secp256k1/key.rb
+++ b/lib/secp256k1/key.rb
@@ -104,7 +104,7 @@ module Secp256k1
 
       msg32 = hash32 msg, raw, digest
 
-      !!C.secp256k1_ecdsa_verify(@ctx, raw_sig, msg32, @public_key)
+      C.secp256k1_ecdsa_verify(@ctx, raw_sig, msg32, @public_key) == 1
     end
 
     def ecdh(scalar)


### PR DESCRIPTION
!!C.secp256k1_ecdsa_verify(@ctx, raw_sig, msg32, @public_key) will always return true no matter whether C.secp256k1_ecdsa_verify(@ctx, raw_sig, msg32, @public_key) will return 0 or 1.