### PR TITLE
Bump to 0.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    bitcoin-secp256k1 (0.5.0)
+    bitcoin-secp256k1 (0.5.1)
       ffi (>= 1.9.25)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.9.25)
+    ffi (1.10.0)
     minitest (5.11.3)
     rake (12.3.2)
     yard (0.9.16)

--- a/lib/secp256k1/version.rb
+++ b/lib/secp256k1/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : ascii-8bit -*-
 module Secp256k1
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
Releasing `v0.5.1` which fixes a `ecdsa_verify` bug (#12). 